### PR TITLE
2 Spellings 2 Pronunciations

### DIFF
--- a/text/chapters-psp-n7/C_IL2D3_2.txt
+++ b/text/chapters-psp-n7/C_IL2D3_2.txt
@@ -29,7 +29,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 『７月７日（日）──杜紀司祭』%K%P
-「July 7th (Sunday)―(杜紀司) Festival」.
+「July 7th (Sunday)―Mori-Ki-Shi Festival」.
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -44,7 +44,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 （杜紀司祭%T030──ときつかさまつり、%T015か？）%K%P
-((杜紀司) Festival―The 「Tokitsukasa」 Festival, huh?)
+(「Mori-Ki-Shi Festival」―I think it should be pronounced 「Tokitsukasa Festival」?)
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -54,7 +54,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 （──えっ！？　──杜・紀・司？？？）%K%P
-(―What!? ―To(杜)-ki(紀)-tsukasa(司)???)
+(―What!? 「Mori」, 「Ki」, 「Shi」???)
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -64,7 +64,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 優夏「とりゃぁ〜〜〜！」%K%P
-Toryaa!
+Toryaaa!
 CN PLACEHOLDER
 RU PLACEHOLDER
 

--- a/text/chapters-psp-n7/C_IL2D7.txt
+++ b/text/chapters-psp-n7/C_IL2D7.txt
@@ -909,12 +909,12 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 『７月６日（土）──司紀杜祭』%K%N
-「July 6th (Saturday)―Shiki no Mori(司紀杜) Festival.」
+「July 6th (Saturday)―Shi-Ki-Mori Festival.」
 CN PLACEHOLDER
 RU PLACEHOLDER
 
 『７月７日（日）──杜紀司祭』%K%N
-「July 7th (Sunday)―Tokitsukasa (杜紀司) Festival」.
+「July 7th (Sunday)―Mori-Ki-Shi Festival」.
 CN PLACEHOLDER
 RU PLACEHOLDER
 

--- a/text/chapters-psp-n7/ILUNA.txt
+++ b/text/chapters-psp-n7/ILUNA.txt
@@ -1114,7 +1114,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 あの死鬼の神の伝説を、本気で信じてるからか？%K%P
-Does she seriously believe that story about the God of Demons?
+Does she seriously believe that story about the Demon of Death?
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1164,7 +1164,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 あの死鬼の神の伝説を、本気で信じてるからか？%K%P
-Does she seriously believe that story about the God of Killer Demons?
+Does she seriously believe that story about the Demon of Death?
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1214,7 +1214,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 いづみ「誠くん……聞いてなかったの？%Nだからあそこには、死鬼の神がっ」%K%P
-Makoto-kun... Weren't you listening? It's because over there is the God of De-
+Makoto-kun... Weren't you listening? It's because over there is the Demon of De-
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1259,7 +1259,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 『死鬼の神の真相を知っている』
-「I know the truth about the God of Demons.」
+「I know the truth about the Demon of Death.」
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1304,7 +1304,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 誠「いづみさん……実はオレ、死鬼の神の真相を知ってるんだ」%K%P
-Izumi-san... I know the truth about the God of Demons.
+Izumi-san... I know the truth about the Demon of Death.
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1339,7 +1339,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 ──死鬼の神の伝説が、いづみさんの創作だったってことか！？%K%P
-―So that means she created the story about the God of Demons!?
+―So that means she created the story about the Demon of Death?!
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1464,7 +1464,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 いづみ「月浜で、私が話した死鬼の神の話……」%K%P
-The story about the God of Demons I told you about on Moon Beach...
+The story about the Demon of Death I told you about on Moon Beach...
 CN PLACEHOLDER
 RU PLACEHOLDER
 

--- a/text/chapters-psp-n7/KJINJYA.txt
+++ b/text/chapters-psp-n7/KJINJYA.txt
@@ -74,7 +74,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 くるみ「ん？　……まさか、お兄ちゃんまで信じてるわけじゃないよねぇ？　あの『死鬼の神』とかいう伝説の話……」%K%P
-Huh? ... Don't tell Kurumi that even you believe that story about 『The God of Demons』...?
+Huh? ... Don't tell Kurumi that even you believe that story about the 『Demon of Death』...?
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -329,7 +329,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 くるみ「例えば、あの死鬼の神が神社の中からぬら〜んと現れて、くるみのことを捕まえようとしたら？」%K
-For example, what if that God of Demons appears in the shrine and tries to grab Kurumi?
+For example, what if that Demon of Death appears in the shrine and tries to grab Kurumi?
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -504,7 +504,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 誠「死鬼の神だの何だのって話も、今は関係無い」%K%P
-It has nothing to do with the story of the God of Demons either.
+It has nothing to do with the story of the Demon of Death either.
 CN PLACEHOLDER
 RU PLACEHOLDER
 

--- a/text/chapters-psp-n7/KL2D4_3.txt
+++ b/text/chapters-psp-n7/KL2D4_3.txt
@@ -449,7 +449,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 誠「いづみさん……実はオレ、死鬼の神の真相を知ってるんだ」%K%P
-Izumi-san... I know the truth about the God of Demons.
+Izumi-san... I know the truth about the Demon of Death.
 CN PLACEHOLDER
 RU PLACEHOLDER
 

--- a/text/chapters-psp-n7/L1D2N_1.txt
+++ b/text/chapters-psp-n7/L1D2N_1.txt
@@ -244,22 +244,22 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 いづみ「あそこ……正式な名前を『司紀の杜神社』って言うんだけど、一説によると、昔は『死ぬ鬼の杜』と書いて『死鬼の杜』と呼んでいたっていう噂もあるの」%K%P
-That shrine... its official name is the 『Shiki no Mori Shrine』 (司紀の杜神社), but they say long ago, it was known as the 『Grove of Demons』, written as 『Shiki no Mori』 (死鬼の杜).
+That shrine... its proper name is the 『Shiki no Mori Shrine』, written as 『Shi-Ki-Mori』, but they say long ago, the characters used for 『Shi』 and 『Ki』 were different.
 CN PLACEHOLDER
 RU PLACEHOLDER
 
 いづみ「つまりあの神社は、その『死鬼の神』を崇め奉る為に建てられたのだ、と……そういうことみたい」%K%P
-In other words, that shrine was built to worship the 『God of Demons』... or so they say.
+According to this old spelling, the shrine would have been built to worship the 『Demon of Death』... or so it seems.
 CN PLACEHOLDER
 RU PLACEHOLDER
 
 いづみさんが砂浜に『司紀杜』『死鬼杜』と、指先で書きながら説明を続ける。%K%P
-Izumi-san continues to explain while writing the two different ways of writing 『Shiki no Mori』 in the sand ((司紀杜) and (死鬼杜)).
+As Izumi-san continues her explanations, she uses her finger to write 「Shi-Ki-Mori」 in the sand in the two different ways (司紀杜 / 死鬼杜).
 CN PLACEHOLDER
 RU PLACEHOLDER
 
 いづみ「『死鬼の神』というのは、文字どおり『死をつかさどる鬼神』の意味で、人々を呪い殺したり祟ったりする凶暴な邪神のこと」%K%P
-This means the 『God of Demons』 was literally 『The Fierce God Who Rules Over Death』. He was a brutal, evil god that would curse and kill people.
+『Death』 (死) for 『Shi』, and 『demon』 (鬼) for 『Ki』, meaning 『a demon who rules over death』. A violent, evil god, that would curse and kill people.
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -524,7 +524,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 いづみ「島の人達は、その一連の『神隠し事件』のことを『死鬼の神の祟りだ』とか『死鬼の神が地獄に引きずり込んだのだ』とか、そんなふうに言ってる」%K%P
-The people on this island say that this series of 『spiriting away』 incidents were from the people being 『cursed』, or 『dragged to hell by the God of Demons』.
+The people on this island say that this series of 『spiriting away』 incidents were from the people being 『cursed』, or 『dragged to hell by the Demon of Death』.
 CN PLACEHOLDER
 RU PLACEHOLDER
 

--- a/text/chapters-psp-n7/L1D2N_1.txt
+++ b/text/chapters-psp-n7/L1D2N_1.txt
@@ -259,7 +259,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 いづみ「『死鬼の神』というのは、文字どおり『死をつかさどる鬼神』の意味で、人々を呪い殺したり祟ったりする凶暴な邪神のこと」%K%P
-『Death』 (死) for 『Shi』, and 『demon』 (鬼) for 『Ki』, meaning 『a demon who rules over death』. A violent, evil god, that would curse and kill people.
+『Death』 (死) for 『Shi』, and 『demon』 (鬼) for 『Ki』, meaning 『a demon who rules over death』. A violent, evil god that would curse and kill people.
 CN PLACEHOLDER
 RU PLACEHOLDER
 

--- a/text/chapters-psp-n7/L1D4N.txt
+++ b/text/chapters-psp-n7/L1D4N.txt
@@ -1594,7 +1594,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 『司紀杜』%K──札にはそう書かれていた。%K%P
-「Shiki no Mori」―That's what's written on it.
+Characters for 「Shi-Ki-Mori」... That's what's written on it.
 CN PLACEHOLDER
 RU PLACEHOLDER
 

--- a/text/chapters-psp-n7/YL1D5_2.txt
+++ b/text/chapters-psp-n7/YL1D5_2.txt
@@ -1569,7 +1569,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 優夏「やっぱりそうだったんだよ！」%K%P
-Playing around with words... that's it!
+That's what it is... that's it!
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1674,7 +1674,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 誠「例の『死鬼の神』の話をした時のことだろ？」%K%P
-You mean when she told us about the 『God of the Demons』, right?
+You mean when she told us about the 『Demon of Death』, right?
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1869,7 +1869,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 そう言って、優夏が指差した方向は、神社の軒下のあたりだった。%K%P
-Yuka points her finger towards the roof of the shrine.
+Yuka points her finger towards the eaves of the shrine.
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1879,17 +1879,17 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 『司紀杜』──札にはそう書かれていた。%K%P
-Shiki no Mori (司紀杜)―that's what's written on it.
+Characters for 「Shi-Ki-Mori」... That's what's written on it.
 CN PLACEHOLDER
 RU PLACEHOLDER
 
 誠「しきのもり……それがどうしたんだ？」%K%P
-Shiki no Mori... What about it?
+『Shiki no Mori』... What about it?
 CN PLACEHOLDER
 RU PLACEHOLDER
 
 優夏「じゃあ、今度は逆から読んでみて？」%K%P
-Could you try reading the characters backwards this time?
+Could you try reading the characters right to left this time?
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1899,7 +1899,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 誠「優夏……おまえまさか、また下らない回文でも思いついたんじゃないだろうな？」%K%P
-Yuka, you said 『playing around with words』 just before we left the shop. This isn't another one of your stupid portmanteau jokes like 『Kurumilk』 or 『Ishiitakehara,』 is it?
+Yuka, this isn't another one of your stupid portmanteau jokes like 『Kurumilk』 or 『Ishiitakehara』, is it?
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1909,12 +1909,12 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 誠「『司紀杜』の逆だから……『杜紀司（もりのきし）』だろ？」%K%P
-Shiki no Mori backwards is... Mori no Kishi (杜紀司), right?
+『Shi-Ki-Mori』 backwards is... 『Mori-Ki-Shi』, right?
 CN PLACEHOLDER
 RU PLACEHOLDER
 
 優夏「『杜（もり）』は音読みだと、何て読む？」%K%P
-And how do you read 『Mori』 (杜) if you're using its Chinese reading?
+And how do you read 『Mori』 if you're using its Chinese reading?
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1924,7 +1924,7 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 優夏「『司（し）』は訓読みだと？」%K%P
-Since the 『Shi』 (司) character is its Chinese reading, how would you read that in Japanese?
+And if you read 『Shi』 using its Japanese reading?
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1934,17 +1934,17 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 優夏「それを通して読んだら？」%K%P
-And the 『Ki』 (紀) part is the same in both, so how would you read it now?
+And if you read it all together like that?
 CN PLACEHOLDER
 RU PLACEHOLDER
 
 誠「と・%Wき・%Wつかさ……」%K%P
-To-ki-tsukasa... 『to rule time』...
+『To-Ki-Tsukasa』... 『To rule time』...
 CN PLACEHOLDER
 RU PLACEHOLDER
 
 誠「──ときつかさ！？」%K%P
-―To rule time!?
+―To rule time?!
 CN PLACEHOLDER
 RU PLACEHOLDER
 
@@ -1959,17 +1959,17 @@ CN PLACEHOLDER
 RU PLACEHOLDER
 
 優夏「もし仮に、大昔に建てられたものだとしたら、右から左へと読むのが正確な読み方ってことになるよねぇ？」%K%P
-And for argument's sake, if it was something built long ago, then it would have been in a time period when the correct way to read text was from right to left.
+And for argument's sake, if it was something built long ago, then it would have been in a time period when the correct way to read Japanese was still from right to left.
 CN PLACEHOLDER
 RU PLACEHOLDER
 
 優夏「だとすると、この神社の正式名称は『司紀の杜神社』じゃなくって……」%K%P
-If that's the case, then the shrine's formal name isn't the 『Shiki no Mori Shrine』...
+If that's the case, then the shrine's proper name isn't the 『Shiki no Mori Shrine』...
 CN PLACEHOLDER
 RU PLACEHOLDER
 
 誠「『杜紀司（ときつかさ）神社』……」%K%P
-It's the 『Tokitsukasa Shrine』... the 『Time Ruling Shrine』...
+It's the 『Tokitsukasa Shrine』... The 『Time Ruling Shrine』...
 CN PLACEHOLDER
 RU PLACEHOLDER
 


### PR DESCRIPTION
An attempt at improving how the English translation deals with the kanji game involving the names of the two shrines (司紀杜 / 杜紀司).

The idea here, based on the original suggestion by Lord Thantus, is to use only one way of representing the spelling of the name, and only one way of representing the pronunciation of the name, per each shrine, and to clearly establish the relation between the spellings and their corresponding pronunciations.

As part of implementing this, the translation of the horror story told by Izumi has been reworked, with "God of Demons" being renamed as "Demon of Death". All the instances of this character being mentioned have been updated to reflect this.

Finally, the tangentially related "playing around with words" lines were removed/changed, as they lacked the intended subtlety of the original Japanese lines, and felt off.